### PR TITLE
Added function to fetch posts by series

### DIFF
--- a/src/Fragments/PostFragment.php
+++ b/src/Fragments/PostFragment.php
@@ -31,6 +31,21 @@ class PostFragment
             title,
             description
           }
+          series {
+                id
+                name
+                createdAt
+                description {
+                    html,
+                    markdown
+                    text
+                }
+                coverImage
+                cuid
+                slug
+                sortOrder
+                author '.AuthorFragment::handle().'
+            }
         }';
     }
 }

--- a/src/Hashnode.php
+++ b/src/Hashnode.php
@@ -2,6 +2,8 @@
 
 namespace Dcblogdev\Hashnode;
 
+use Dcblogdev\Hashnode\Fragments\AuthorFragment;
+use Dcblogdev\Hashnode\Fragments\ContentFragment;
 use Dcblogdev\Hashnode\Fragments\PostFragment;
 use Dcblogdev\Hashnode\Fragments\PostsFragment;
 use Dcblogdev\Hashnode\Fragments\PublicationFragment;
@@ -81,6 +83,38 @@ class Hashnode
         }
 
         return $response->data->publication->posts;
+    }
+
+    public function getPostsBySeries(string $slug): StdClass
+    {
+        $query = 'query Publication {
+            publication(host: "'.$this->host.'") {
+                series(slug: "'.$slug.'") {
+                    id
+                    name
+                    createdAt
+                    description '.ContentFragment::handle().'
+                    coverImage
+                    author '.AuthorFragment::handle().'
+                    cuid
+                    slug
+                    sortOrder
+                    '.PostsFragment::handle($this->perPage, $this->getAfter()).'
+                }
+            }
+        }';
+
+        $response = $this->getResponse($query);
+
+        if (! property_exists($response, 'data')) {
+            abort(400, 'Data not found in response');
+        }
+
+        if (! property_exists($response, 'series')) {
+            abort(400, 'Series not found in response');
+        }
+
+        return $response->data->publication->series;
     }
 
     public function getPost(string $slug): stdClass


### PR DESCRIPTION
Introduced the method 'getPostsBySeries' in the Hashnode.php file. It fetches posts from a specific series based on the given series slug.